### PR TITLE
Fix the unordered dicts problem

### DIFF
--- a/dicts/dicts.py
+++ b/dicts/dicts.py
@@ -28,16 +28,11 @@ class DictLoader:
 
     @staticmethod
     def from_path(
-        path: Path,
-        skip_errors=False,
-        disabled_key: str = "disabled",
-        load_disabled: bool = False,
+        path: Path, skip_errors=False, disabled_key: str = "disabled", load_disabled: bool = False
     ):
         loader = DictLoader(path, skip_errors=skip_errors)
         loader.items = list(
-            DictLoader.remove_disabled_items(
-                loader.directory(), disabled_key, load_disabled
-            )
+            DictLoader.remove_disabled_items(loader.directory(), disabled_key, load_disabled)
         )
         return loader
 
@@ -49,13 +44,13 @@ class DictLoader:
         load_disabled: bool = False,
     ):
         loader = DictLoader(None, skip_errors=skip_errors)
-        loader.items = list(
-            DictLoader.remove_disabled_items(dicts, disabled_key, load_disabled)
-        )
+        loader.items = list(DictLoader.remove_disabled_items(dicts, disabled_key, load_disabled))
         return loader
 
     @staticmethod
-    def remove_disabled_items(items: Iterable[Dict], disabled_key: str, load_disabled: bool) -> Iterable[Dict]:
+    def remove_disabled_items(
+        items: Iterable[Dict], disabled_key: str, load_disabled: bool
+    ) -> Iterable[Dict]:
         if load_disabled:
             log.debug("load_disabled_items flag is True")
             return list(items)
@@ -120,7 +115,8 @@ class DictLoader:
     ) -> Iterable[Dict[str, List[Any]]]:
         key_func = (lambda d: d.get(key, default_group)) if isinstance(key, str) else key
         transformator_func = transformator or (lambda x: x)
-        for k, v in groupby(self.items, key=key_func):
+        items = sorted(self.items, key=key_func)
+        for k, v in groupby(items, key=key_func):
             yield (k, list(map(transformator_func, v)))
 
     def group_by_key(

--- a/dicts/tests.py
+++ b/dicts/tests.py
@@ -95,6 +95,13 @@ def test_to_dict_transform():
     assert out[a[0]["a"]] == a[0]["b"]
 
 
+def test_group_by_unordered():
+    a = [{PATH_KEY: "a"}, {PATH_KEY: "c"}, {PATH_KEY: "b"}, {PATH_KEY: "a"}]
+    loader = DictLoader.from_dicts(a)
+    out = loader.group_by_file()
+    assert len(out["a"]) == 2
+
+
 def test_duplicate():
     a = [{"name": 1, PATH_KEY: "x"}, {"name": 1, PATH_KEY: "y"}]
     loader = DictLoader.from_dicts(a)


### PR DESCRIPTION
Citing the documentation of `groupby`:

> The operation of groupby() is similar to the uniq filter in Unix. It generates a break or new group every time the value of the key function changes (which is why it is usually necessary to have sorted the data using the same key function).

This PR adds sorting to the group by operation. Also added a unit test that highlights the problem solved.