### PR TITLE
Psycopg2 binaries

### DIFF
--- a/connections/requirements.txt
+++ b/connections/requirements.txt
@@ -1,5 +1,0 @@
-revlibs-dicts>=0.0.1
-revlibs-logger>=0.0.2
-json-codegen>=0.4.2
-psycopg2>=2.7.7
-pyexasol>=0.5.2

--- a/connections/setup.py
+++ b/connections/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
         "revlibs-dicts>=0.0.1",
         "revlibs-logger>=0.0.2",
-        "psycopg2>=2.7.7",
+        "psycopg2-binary>=2.8",
         "pyexasol>=0.5.2",
     ],
     namespace_packages=["revlibs"],


### PR DESCRIPTION
Use `psycopg2-binary` package to avoid installing the whole development libraries of PostgreSQL to install this package