### PR TITLE
Fix: Raise meaningful exception on failing to connect to an Exasol database

### DIFF
--- a/connections/resources/test_connections/exasol_bad_dsn.yaml
+++ b/connections/resources/test_connections/exasol_bad_dsn.yaml
@@ -1,0 +1,6 @@
+- name: exasol_bad_dsn
+  flavour: exasol
+  dsn: bad_dsn:8888
+  user: test
+  password: _env:TEST_PASS
+  schema: s

--- a/connections/revlibs/connections/connectors.py
+++ b/connections/revlibs/connections/connectors.py
@@ -33,8 +33,16 @@ class ConnectExasol:
                 fetch_mapper=pyexasol.exasol_mapper,
                 **params,
             )
-        except pyexasol.exceptions.ExaError as err:
-            log.exception(err)
+        except pyexasol.exceptions.ExaCommunicationError:
+            log.error(
+                f"Could not connect to Exasol: Bad dsn [dsn={self.dsn}, user={self.config.user}]"
+            )
+            raise
+        except pyexasol.exceptions.ExaRequestError:
+            log.error(
+                f"Could not connect to Exasol: Wrong user or password [dsn={self.dsn}, user={self.config.user}]"
+            )
+            raise
         return self.connection
 
     def close(self):

--- a/connections/tests/connectors_test.py
+++ b/connections/tests/connectors_test.py
@@ -84,6 +84,14 @@ def test_multi_server_exasol():
     conn.close.assert_called()
 
 
+@patch.dict("os.environ", TEST_EVIRONMENT)
+def test_bad_dsn_exasol():
+    """ Test passing exasol a bad dsn."""
+    with pytest.raises(pyexasol.exceptions.ExaCommunicationError):
+        with get("exasol_bad_dsn"):
+            pass
+
+
 def test_disabled_connection():
     """ Disabled connections are not handled."""
     with pytest.raises(KeyError):


### PR DESCRIPTION
Fixed incorrect exception raised on failing to connect to an Exasol database. It should raise `pyexasol.exceptions.ExaCommunicationError` or `pyexasol.exceptions.ExaRequestError` instead of `AttributeError`