### PR TITLE
Pass the config path as a variable to load

### DIFF
--- a/connections/README.md
+++ b/connections/README.md
@@ -35,11 +35,12 @@ If you would like to specify a different path.
 
 #### E.g:
 
-You may change the `"REVLIB_CONNECTIONS"`
-environment variable.
+You may specify a different config directory by passing it in the `get` method.
 
-```
-export REVLIB_CONNECTIONS=<path_to_different_file>
+```python
+path = "/home/sebastien/.connections/"
+with connections.get("sandboxdb", config_path=path) as conn:
+    conn.execute(query)
 ```
 
 #### Config

--- a/connections/revlibs/connections/config.py
+++ b/connections/revlibs/connections/config.py
@@ -7,16 +7,20 @@ from revlibs.dicts import DictLoader
 
 
 _DEFAULT_DIRECTORY = Path.home() / ".revconnect/"
-_ENV_VAR_FOR_FILE = "REVLIB_CONNECTIONS"
 _PASSWORD_REQUIRED = (
     # Provide a meaningful message
     "Please ensure you have set the password as an environment variable"
 )
 
 
-def load(database):
-    """ Load the database connection configuration."""
-    loader = load_connection_settings()
+def load(database, **options):
+    """ Load the database connection configuration.
+
+    :param options: **kwargs, pass additional arguments.
+    """
+    directory = Path(options.get("config_path", _DEFAULT_DIRECTORY))
+
+    loader = load_connection_settings(directory)
     candidates = [
         item
         for item in loader.items
@@ -82,8 +86,7 @@ class Config:
         return result
 
 
-def load_connection_settings():
-    """ Retrieve connections from specified yaml."""
-    directory = Path(os.environ.get(_ENV_VAR_FOR_FILE, _DEFAULT_DIRECTORY))
+def load_connection_settings(directory):
+    """ Retrieve connection yaml from a specified directory."""
     loader = DictLoader.from_path(directory)
     return loader

--- a/connections/revlibs/connections/connectors.py
+++ b/connections/revlibs/connections/connectors.py
@@ -96,9 +96,9 @@ _CONNECTORS = {"exasol": ConnectExasol, "postgres": ConnectPostgres}
 
 
 @contextmanager
-def get(name):
+def get(name, **options):
     """ Grab a connection."""
-    cfg = config.load(name)
+    cfg = config.load(name, **options)
     try:
         obj = _CONNECTORS[cfg.flavour]
     except KeyError as err:


### PR DESCRIPTION
I was doing some thinking about this change, and I ran into the same separations of concerns we should have between engineering and data scientist.

Ideally we should not allow a DS to have the config path being configurable since it can lead to a different path for every notebook a DS creates (and they also should not care). I have seen this occur when DS have access to GCS namespaces.

On the other hand it makes sense to have the path configurable for an engineering.

Resolves #18
