### PR TITLE
Allow logger to be parametrizable and decouple handlers

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -6,6 +6,14 @@ Base logging configuration. Includes the following out of the box:
 - writing to file, rotated every hour
 - writing to Google StackDriver, all fields, in json format
 
+## Install
+
+Install basic logger without additional handlers
+
+```
+pip install revlibs-logger
+```
+
 ## Usage
 
 ```python
@@ -41,6 +49,23 @@ log = get_logger(params={"LOG_FILE_LOCATION": "some_other_file.log",  "LOG_LEVEL
 
 ## Handlers
 
+Additional handlers can be specified when installing or as dependencies:
+
+```bash
+revlibs-logger[stackdriver,slack]==0.3.0
+```
+
+These handlers may be included when instantiating your application's logger
+
+```
+logger = get_logger(add_handlers=['console', 'file', 'slack', 'stackdriver'])
+```
+
+For more details on specific handlers see:
+
+- [Stackdriver logging](./README.md#stackdriver-logging)
+- [Slack logging](./README.md#slack-logging)
+
 ### Console
 
 Log levels are displayed colored. Default level is INFO.
@@ -66,7 +91,7 @@ It is also possible to write to slack, using logger called slack.
 You need to set **LOG_SLACK_TOKEN** and **DEFAULT_SLACK_CHANNEL** variables via _params_ or environment:
 
 ```python
-log = get_logger("slack", params={"DEFAULT_SLACK_CHANNEL": "errors", "LOG_SLACK_TOKEN": "<xxxxxxx>"})
+log = get_logger("slack", params={"DEFAULT_SLACK_CHANNEL": "errors", "LOG_SLACK_TOKEN": "<xxxxxxx>"}, add_handlers=['console', 'file', 'slack'])
 ```
 
 Additional properties:

--- a/logger/revlibs/logger/__init__.py
+++ b/logger/revlibs/logger/__init__.py
@@ -1,16 +1,15 @@
-from typing import Optional, Union
+from typing import Union
 
 import logging
 import logging.config
 
 from os import environ, _Environ
-from pathlib import Path
 from pkgutil import get_data
 
 import yaml
 
 from .formatters import color_formatter
-from .formatters import stackdriver_formatter
+
 
 DEFAULTS = {
     "LOG_FILE_LOCATION": "/tmp/python-log.log",
@@ -20,12 +19,9 @@ DEFAULTS = {
     "LOG_LEVEL_FILE": "DEBUG",
     "LOG_SLACK_USER": "Logger",
     "DEFAULT_SLACK_CHANNEL": "NOT_SET",
-    "LOG_SLACK_TOKEN": "NOT_SET",  # This should be overriden, otherwise message will not be sent
+    "LOG_SLACK_TOKEN": "NOT_SET",  # This should be overridden, otherwise message will not be sent
 }
-
 STACKDRIVER_LOGGING_ENABLE_VAR = "STACKDRIVER_LOGGING_ENABLE"
-
-
 LOGGING_CONFIG_LOCATION = environ.get("LOG_CONFIG_PATH")
 
 
@@ -41,23 +37,42 @@ def _load_logging_config_(params):
         if config_data:
             config_str = config_data.decode("utf-8")
         else:
-            raise Exception("Coould not find default logging.yaml")
+            raise Exception("Could not find default logging.yaml")
     return yaml.load(config_str.format(**params), Loader=yaml.Loader)
 
 
-def get_logger(name=None, params: Union[dict, _Environ] = None):
+def select_handlers(names, config):
+    """ This filters out the handlers specified in log config."""
+    handlers = config['handlers'].copy()
+    for handler_name in handlers.keys():
+        if handler_name not in names:
+            config['handlers'].pop(handler_name)
+
+    if 'slack' not in names:
+        config['loggers'].pop('slack')
+
+    return config
+
+
+def get_logger(name=None, params: Union[dict, _Environ] = None, add_handlers=["console", "file"]):
     """
     Initialise the logger using the logging.yaml template
     Use environ() where no parameters are specified
+
+    Logs to 'console' and 'file' by default.
     """
     if not params:
         params = environ
 
     config = _load_logging_config_(params)
+    config = select_handlers(add_handlers, config)
     logging.config.dictConfig(config)
     log = logging.getLogger(name)
 
-    if params.get(STACKDRIVER_LOGGING_ENABLE_VAR, "FALSE").upper() == "TRUE":
+    # Add stackdriver handler
+    if 'stackdriver' in add_handlers:
+        from .formatters import stackdriver_formatter
+
         log.info("STACKDRIVER enabled")
         stackdriver_formatter.add_stack_driver_support(log)
 

--- a/logger/revlibs/logger/resources/logging.yaml
+++ b/logger/revlibs/logger/resources/logging.yaml
@@ -18,7 +18,7 @@ handlers:
         formatter: simple
         filename: "{LOG_FILE_LOCATION}"
         when: "{LOG_ROTATING_INTERVAL}"
-    slack: 
+    slack:
         username: "{LOG_SLACK_USER}"
         level: DEBUG
         fail_silent: true

--- a/logger/setup.py
+++ b/logger/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="revlibs-logger",
-    version="0.2.0",
+    version="0.3.0",
     author="Demeter Sztanko",
     author_email="demeter.sztanko@revolut.com",
     packages=find_packages(),
@@ -11,8 +11,10 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "pyaml>=18.11.0",
-        "google-cloud-logging>=1.10.0",
-        "slacker-log-handler>=1.7.1",
     ],
+    extra_requires={
+        "slack": ["slacker-log-handler>=1.7.1"],
+        "stackdriver": ["google-cloud-logging>=1.10.0"],
+    },
     namespace_packages=["revlibs"],
 )


### PR DESCRIPTION
The state of this logger needs improvement. I have attempted to avoid increasing technical debt and allowed the logger to become usable without requiring some of it's dependencies which may cause issue further downstream.

The bulk of this PR can be summed as presented:

---

Additional handlers can be specified when installing or as dependencies:

```bash
revlibs-logger[stackdriver,slack]==0.3.0
```

These handlers may be included when instantiating your application's logger

```python
logger = get_logger(add_handlers=['console', 'file', 'slack', 'stackdriver'])
```