### PR TITLE
Allow connections without specified schema (#42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.idea/
+
 # C extensions
 *.so
 *.log*

--- a/connections/resources/test_connections/exasol_empty_schema.yaml
+++ b/connections/resources/test_connections/exasol_empty_schema.yaml
@@ -1,0 +1,5 @@
+- name: exasol_empty_schema
+  flavour: exasol
+  dsn: 127.0.0.1:5436
+  user: test
+  password: _env:TEST_PASS

--- a/connections/revlibs/connections/connectors.py
+++ b/connections/revlibs/connections/connectors.py
@@ -22,7 +22,10 @@ class ConnectExasol:
     def connect(self):
         """ Attempt to connect to exasol."""
         schema = self.config.schema if ("schema" in self.config) else None
-        params = {"schema": schema, "compression": True}
+        params = {"compression": True}
+        if schema:
+            params["schema"] = schema
+
         params.update(self.config.params)
         try:
             self.connection = pyexasol.connect(

--- a/connections/tests/connectors_test.py
+++ b/connections/tests/connectors_test.py
@@ -66,6 +66,24 @@ def test_multi_server_postgres():
 
 
 @patch.dict("os.environ", TEST_EVIRONMENT)
+def test_empty_schema_exasol():
+    """ Test passing exasol multiple connections."""
+    with patch("pyexasol.connect") as mocked_conn:
+        with get("exasol_empty_schema") as conn:
+            pass
+
+    mocked_conn.assert_called_with(
+        compression=True,
+        dsn="127.0.0.1:5436",
+        fetch_dict=True,
+        password="IamAwizard",
+        user="test",
+        fetch_mapper=pyexasol.exasol_mapper,
+    )
+    conn.close.assert_called()
+
+
+@patch.dict("os.environ", TEST_EVIRONMENT)
 def test_multi_server_exasol():
     """ Test passing exasol multiple connections."""
     with patch("pyexasol.connect") as mocked_conn:


### PR DESCRIPTION
Fixes issue #42 by not specifying schema in connection params if none is provided in configuration.