### PR TITLE
Fix skipped log messages when failing to connect to postgres

### DIFF
--- a/connections/revlibs/connections/connectors.py
+++ b/connections/revlibs/connections/connectors.py
@@ -85,7 +85,10 @@ class ConnectPostgres:
             except psycopg2.OperationalError as err:
                 log.exception(err)
                 continue
-        return self.connection
+        try:
+            return self.connection
+        except AttributeError:
+            raise Exception(f"Could not connect to {self.config.name}")
 
     def close(self):
         """ Close the connection."""

--- a/connections/setup.py
+++ b/connections/setup.py
@@ -3,15 +3,11 @@ from setuptools import setup, find_packages
 
 setup(
     name="revlibs-connections",
-    version="0.1.1",
+    version="0.1.2",
     author="Demeter Sztanko",
     author_email="demeter.sztanko@revolut.com",
     packages=find_packages(),
     python_requires=">=3.6",
-    install_requires=[
-        "revlibs-dicts>=0.0.1",
-        "psycopg2-binary>=2.8",
-        "pyexasol>=0.6",
-    ],
+    install_requires=["revlibs-dicts>=0.0.1", "psycopg2-binary>=2.8", "pyexasol>=0.12",],
     namespace_packages=["revlibs"],
 )

--- a/logger/revlibs/logger/resources/logging.yaml
+++ b/logger/revlibs/logger/resources/logging.yaml
@@ -1,4 +1,5 @@
 version: 1
+disable_existing_loggers: false
 formatters:
     simple:
         # (): logging.Formatter

--- a/logger/setup.py
+++ b/logger/setup.py
@@ -2,16 +2,14 @@ from setuptools import setup, find_packages
 
 setup(
     name="revlibs-logger",
-    version="0.3.3",
+    version="0.3.4",
     author="Demeter Sztanko",
     author_email="demeter.sztanko@revolut.com",
     packages=find_packages(),
     package_data={"logger": ["logging.yaml"]},
     include_package_data=True,
     python_requires=">=3.6",
-    install_requires=[
-        "pyaml>=18.11.0",
-    ],
+    install_requires=["pyaml>=18.11.0",],
     extras_require={
         "slack": ["slacker-log-handler>=1.7.1"],
         "stackdriver": ["google-cloud-logging>=1.10.0"],


### PR DESCRIPTION
- Specify disable_existing_loggers  as False so that the logger used in revlibs connections don't disable existing loggers
- Raise an exception when we fail to connect to all specified postgres DB, instead of just having "AttributeError: 'ConnectPostgres' object has no attribute 'connection'"
- Bump pyexasol version to 0.12