### PR TITLE
Add connectors interface to revlibs.connections

### DIFF
--- a/connections/README.md
+++ b/connections/README.md
@@ -18,8 +18,15 @@ pip install revlibs-connections
 
 from revlibs import connections
 
+# Using context manager
 with connections.get("sandboxdb") as conn:
     conn.execute(query)
+
+# Using connector object
+connector = connections.get_connector("sandboxdb")
+conn = connector.get_connection()
+conn.execute(query)
+connector.close()
 ```
 
 ### Connections

--- a/connections/resources/test_connections/unknown_flavour.yaml
+++ b/connections/resources/test_connections/unknown_flavour.yaml
@@ -1,0 +1,3 @@
+- name: unknown_flavour
+  flavour: newdb
+  dsn: 127.0.0.1:2222

--- a/connections/revlibs/connections/__init__.py
+++ b/connections/revlibs/connections/__init__.py
@@ -1,1 +1,1 @@
-from revlibs.connections.connectors import get
+from revlibs.connections.interface import get, get_connector

--- a/connections/revlibs/connections/connectors.py
+++ b/connections/revlibs/connections/connectors.py
@@ -1,5 +1,6 @@
 """Connectors classes"""
 from abc import ABC, abstractmethod
+from typing import Generator
 
 import psycopg2
 import pyexasol
@@ -15,24 +16,30 @@ class BaseConnector(ABC):
         self.config = cfg
         self.connection = None
 
+    @staticmethod
     @abstractmethod
-    def _connect(self):
+    def _connect(config: Config):
         """Establish connection with database"""
         pass
 
+    @staticmethod
     @abstractmethod
-    def is_connection_closed(self):
-        """Checks if connection with database closed already"""
+    def _is_connection_closed(connection) -> bool:
+        """Check if connection with database closed already"""
         pass
+
+    def is_connected(self) -> bool:
+        """Check if connection with database established and not closed"""
+        return bool(self.connection and not self._is_connection_closed(self.connection))
 
     def get_connection(self):
         """Open new DB connection or return already established if its not closed"""
-        if self.connection and not self.is_connection_closed():
+        if self.is_connected():
             return self.connection
-        self.connection = self._connect()
+        self.connection = self._connect(self.config)
         return self.connection
 
-    def close(self):
+    def close(self) -> None:
         """Close connection to database"""
         if not self.connection:
             return
@@ -43,57 +50,55 @@ class BaseConnector(ABC):
 class ExasolConnector(BaseConnector):
     """Connector class for Exasol DB"""
 
-    def is_connection_closed(self) -> bool:
+    @staticmethod
+    def _is_connection_closed(connection: pyexasol.ExaConnection) -> bool:
         """Check if connection with database closed already"""
-        return self.connection.is_closed
+        return connection.is_closed
 
-    def _connect(self) -> pyexasol.ExaConnection:
+    @staticmethod
+    def _connect(config: Config) -> pyexasol.ExaConnection:
         """Establish connection with exasol"""
         params = {"compression": True}
-        if "schema" in self.config:
-            params["schema"] = self.config.schema
-        params.update(self.config.params)
+        if "schema" in config:
+            params["schema"] = config.schema
+        params.update(config.params)
 
         try:
             return pyexasol.connect(
-                dsn=self.config.dsn,
-                user=self.config.user,
-                password=self.config.password,
+                dsn=config.dsn,
+                user=config.user,
+                password=config.password,
                 fetch_dict=True,
                 fetch_mapper=pyexasol.exasol_mapper,
                 **params,
             )
         except pyexasol.exceptions.ExaConnectionDsnError as exc:
-            raise ConnectionEstablishError(
-                self.config.name, reason="Bad dsn", dsn=self.config.dsn
-            ) from exc
+            raise ConnectionEstablishError(config.name, reason="Bad dsn", dsn=config.dsn) from exc
         except pyexasol.exceptions.ExaAuthError as exc:
             raise ConnectionEstablishError(
-                self.config.name,
-                reason="Authentication failed",
-                dsn=self.config.dsn,
-                user=self.config.user,
+                config.name, reason="Authentication failed", dsn=config.dsn, user=config.user,
             ) from exc
         except pyexasol.exceptions.ExaConnectionFailedError as exc:
             raise ConnectionEstablishError(
-                self.config.name, reason="Connection refused", dsn=self.config.dsn,
+                config.name, reason="Connection refused", dsn=config.dsn,
             ) from exc
         except pyexasol.exceptions.ExaError as exc:
-            raise ConnectionEstablishError(self.config.name, dsn=self.config.dsn) from exc
+            raise ConnectionEstablishError(config.name, dsn=config.dsn) from exc
 
 
 class PostgresConnector(BaseConnector):
     """Connector class for PostgreSQL DB"""
 
-    def is_connection_closed(self) -> bool:
+    @staticmethod
+    def _is_connection_closed(connection: psycopg2.extensions.connection) -> bool:
         """Check if connection with database closed already"""
-        return self.connection.closed
+        return connection.closed
 
     @staticmethod
-    def _parse_dsn(data_source_name: str) -> str:
+    def _parse_dsn(data_source_name: str) -> Generator[str, None, None]:
         """Convert connection URI to key/value connection string.
 
-        >>> _parse_dsn('localhost:8888, 127.0.0.1:6543')
+        >>> list(PostgresConnector._parse_dsn('localhost:8888, 127.0.0.1:6543'))
         ['host=localhost port=8888', 'host=127.0.0.1 port=6543']
         """
         dsns = data_source_name.split(",")
@@ -101,26 +106,27 @@ class PostgresConnector(BaseConnector):
             host, port = dsn.strip().split(":")
             yield f"host={host} port={port}"
 
-    def _connect(self) -> psycopg2.extensions.connection:
+    @staticmethod
+    def _connect(config: Config) -> psycopg2.extensions.connection:
         """Establish connection with postgres"""
-        dbname = self.config.dbname if ("dbname" in self.config) else None
+        dbname = config.dbname if "dbname" in config else None
 
         connection, last_exception = None, None
-        for dsn in self._parse_dsn(self.config.dsn):
+        for dsn in PostgresConnector._parse_dsn(config.dsn):
             try:
                 connection = psycopg2.connect(
                     dsn,
-                    user=self.config.user,
-                    password=self.config.password,
+                    user=config.user,
+                    password=config.password,
                     dbname=dbname,
-                    **self.config.params,
+                    **config.params,
                 )
             except psycopg2.Error as exc:
                 last_exception = exc
 
         if not connection:
             raise ConnectionEstablishError(
-                self.config.name, dsn=self.config.dsn, user=self.config.user, dbname=dbname,
+                config.name, dsn=config.dsn, user=config.user, dbname=dbname,
             ) from last_exception
 
         return connection

--- a/connections/revlibs/connections/exceptions.py
+++ b/connections/revlibs/connections/exceptions.py
@@ -1,0 +1,23 @@
+"""Definitions of exceptions raised by connections library"""
+
+
+class DatabaseConnectionError(Exception):
+    """Base exception for problems with establishment of database connection"""
+
+    def __init__(self, connection_name: str, reason: str = "", **kwargs) -> None:
+        self.message = f"Could not connect to {connection_name}"
+        if reason:
+            self.message = f"{self.message}: {reason}"
+        if kwargs:
+            params = " ".join(f"{k}={v}" for k, v in kwargs.items())
+            self.message = f"{self.message} [{params}]"
+
+        super().__init__(self.message)
+
+
+class ConnectionParamsError(DatabaseConnectionError):
+    """Raised when there is a problem with connection params"""
+
+
+class ConnectionEstablishError(DatabaseConnectionError):
+    """Raised when connection to database cannot be established"""

--- a/connections/revlibs/connections/interface.py
+++ b/connections/revlibs/connections/interface.py
@@ -6,13 +6,13 @@ import psycopg2
 import pyexasol
 
 from revlibs.connections import config
-from revlibs.connections.connectors import ExasolConnector, PostgresConnector
+from revlibs.connections.connectors import BaseConnector, ExasolConnector, PostgresConnector
 from revlibs.connections.exceptions import ConnectionParamsError
 
 CONNECTORS = {"exasol": ExasolConnector, "postgres": PostgresConnector}
 
 
-def get_connector(name: str) -> Union[ExasolConnector, PostgresConnector]:
+def get_connector(name: str) -> BaseConnector:
     """Return connector object used for handling of connection.
 
     Database connection parameters will be loaded from YAML/JSON config stored

--- a/connections/revlibs/connections/interface.py
+++ b/connections/revlibs/connections/interface.py
@@ -1,0 +1,77 @@
+"""Standard connection interfaces"""
+from contextlib import contextmanager
+from typing import Iterator, Union
+
+import psycopg2
+import pyexasol
+
+from revlibs.connections import config
+from revlibs.connections.connectors import ExasolConnector, PostgresConnector
+from revlibs.connections.exceptions import ConnectionParamsError
+
+CONNECTORS = {"exasol": ExasolConnector, "postgres": PostgresConnector}
+
+
+def get_connector(name: str) -> Union[ExasolConnector, PostgresConnector]:
+    """Return connector object used for handling of connection.
+
+    Database connection parameters will be loaded from YAML/JSON config stored
+    in `~/.revconnect/` directory or another path specified by environment
+    variable `REVLIB_CONNECTIONS`.
+
+    Opened connection should always be closed when it's not needed anymore,
+    using connector `close()` method or from connection (`connection.close()`)
+
+    Connector object will store established database connection inside, so on
+    first call of method `get_connection()` it will open new connection and on
+    next calls it will be returning already established connection unless
+    connection will be closed using its internal method (`connection.close()`)
+    or through connector object method `close()`.
+
+    Example::
+        connector = get_connector("exasol_db")
+        connection = connector.get_connection()  # open new connection
+        connection.execute("SELECT * FROM table1;")
+        connector.get_connection()  # return already established connection
+        connection.close()
+        connection = connector.get_connection()  # open new connection
+        ...
+        connector.close()  # close connection
+
+    Raises:
+        ConnectionParamsError: If connection params in config are invalid
+        ConnectionEstablishError: If connection cannot be established
+    """
+    try:
+        cfg = config.load(name)
+    except KeyError as exc:
+        raise ConnectionParamsError(name, reason=exc.args[0])
+
+    try:
+        connector_class = CONNECTORS[cfg.flavour]
+    except KeyError:
+        raise ConnectionParamsError(name, reason=f"unsupported database type {cfg.flavour}")
+
+    return connector_class(cfg)
+
+
+@contextmanager
+def get(name: str) -> Iterator[Union[pyexasol.ExaConnection, psycopg2.extensions.connection]]:
+    """Context manager that open connection to database and close it after.
+
+    Database connection parameters will be loaded from YAML/JSON config stored
+    in `~/.revconnect/` directory or another path specified by environment
+    variable `REVLIB_CONNECTIONS`
+
+    Example::
+        with get("exasol_db") as connection:  # open new connection
+            connection.execute("SELECT * FROM table1;")
+        # connection will be closed here
+
+    Raises:
+        ConnectionParamsError: If connection params in config are invalid
+        ConnectionEstablishError: If connection cannot be established
+    """
+    connector = get_connector(name)
+    yield connector.get_connection()
+    connector.close()

--- a/connections/setup.py
+++ b/connections/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="revlibs-connections",
-    version="0.1.3",
+    version="0.2.0",
     author="Demeter Sztanko",
     author_email="demeter.sztanko@revolut.com",
     description="A utility to pre-configure connections regardless of type.",

--- a/connections/tests/connectors_test.py
+++ b/connections/tests/connectors_test.py
@@ -8,12 +8,13 @@ import pytest
 import psycopg2
 import pyexasol
 
-from revlibs.connections import get
+from revlibs.connections import get, get_connector
+from revlibs.connections.exceptions import ConnectionEstablishError, ConnectionParamsError
 
 
 # Environment variables are strings by default
 TEST_CONNECTIONS = Path(__name__).parent / "resources" / "test_connections/"
-TEST_EVIRONMENT = {
+TEST_ENVIRONMENT = {
     "REVLIB_CONNECTIONS": TEST_CONNECTIONS.as_posix(),
     "TEST_PASS": "IamAwizard",
 }
@@ -23,7 +24,7 @@ class ConnectionMock(MagicMock):
     """ Mock connection objects."""
 
 
-@patch.dict("os.environ", TEST_EVIRONMENT)
+@patch.dict("os.environ", TEST_ENVIRONMENT)
 def test_simple_postgres():
     """ Test connection to postgres."""
     with patch("psycopg2.connect") as mocked_conn:
@@ -37,7 +38,7 @@ def test_simple_postgres():
     conn.close.assert_called()
 
 
-@patch.dict("os.environ", TEST_EVIRONMENT)
+@patch.dict("os.environ", TEST_ENVIRONMENT)
 def test_multi_server_postgres():
     """ First host:port fails, handle failover."""
     with patch("psycopg2.connect") as mocked_conn:
@@ -55,7 +56,7 @@ def test_multi_server_postgres():
     conn.close.assert_called()
 
 
-@patch.dict("os.environ", TEST_EVIRONMENT)
+@patch.dict("os.environ", TEST_ENVIRONMENT)
 def test_multi_server_exasol():
     """ Test passing exasol multiple connections."""
     with patch("pyexasol.connect") as mocked_conn:
@@ -74,27 +75,112 @@ def test_multi_server_exasol():
     conn.close.assert_called()
 
 
-@patch.dict("os.environ", TEST_EVIRONMENT)
+@patch.dict("os.environ", TEST_ENVIRONMENT)
 def test_bad_dsn_exasol():
     """ Test passing exasol a bad dsn."""
-    with pytest.raises(pyexasol.exceptions.ExaConnectionDsnError):
+    with pytest.raises(ConnectionEstablishError) as err:
         with get("exasol_bad_dsn"):
             pass
 
+    assert str(err.value) == "Could not connect to exasol_bad_dsn: Bad dsn [dsn=bad_dsn:8888]"
 
+
+@patch.dict("os.environ", TEST_ENVIRONMENT)
 def test_disabled_connection():
     """ Disabled connections are not handled."""
-    with pytest.raises(KeyError):
-        with get("postgres_disabled") as connection:
-            assert not connection
+    with pytest.raises(ConnectionParamsError) as err:
+        with get("postgres_disabled"):
+            pass
+
+    assert str(err.value) == (
+        "Could not connect to postgres_disabled: "
+        "Connection settings for 'postgres_disabled' not found."
+    )
 
 
-@patch.dict("os.environ", TEST_EVIRONMENT)
+@patch.dict("os.environ", TEST_ENVIRONMENT)
 def test_failed_connection_postgres():
-    """ First and second host:port fail, an Exception is raised."""
-    with pytest.raises(Exception) as err:
+    """ First and second host:port fail, an ConnectionEstablishError is raised."""
+    with pytest.raises(ConnectionEstablishError) as err:
         with patch("psycopg2.connect") as mocked_conn:
             mocked_conn.side_effect = [psycopg2.OperationalError, psycopg2.OperationalError]
-            with get("postgres_multi_server") as conn:
+            with get("postgres_multi_server"):
                 pass
-    assert str(err.value) == "Could not connect to postgres_multi_server"
+
+    assert str(err.value) == (
+        "Could not connect to postgres_multi_server "
+        "[dsn=127.0.0.1:5436,127.0.0.2:5436 user=test dbname=None]"
+    )
+
+
+@patch.dict("os.environ", TEST_ENVIRONMENT)
+def test_pyexasol_exceptions():
+    with patch("pyexasol.connect") as mocked_conn:
+        mocked_conn.side_effect = [
+            pyexasol.exceptions.ExaAuthError(None, None, None),
+            pyexasol.exceptions.ExaConnectionFailedError(None, None),
+            pyexasol.exceptions.ExaRuntimeError(None, None),
+        ]
+
+        with pytest.raises(ConnectionEstablishError) as err:
+            get_connector("exasol_multi_server").get_connection()
+        assert str(err.value) == (
+            "Could not connect to exasol_multi_server: Authentication failed "
+            "[dsn=127.0.0.1:5436,127.0.0.2:5437 user=test]"
+        )
+
+        with pytest.raises(ConnectionEstablishError) as err:
+            get_connector("exasol_multi_server").get_connection()
+        assert str(err.value) == (
+            "Could not connect to exasol_multi_server: Connection refused "
+            "[dsn=127.0.0.1:5436,127.0.0.2:5437]"
+        )
+
+        with pytest.raises(ConnectionEstablishError) as err:
+            get_connector("exasol_multi_server").get_connection()
+        assert str(err.value) == (
+            "Could not connect to exasol_multi_server "
+            "[dsn=127.0.0.1:5436,127.0.0.2:5437]"
+        )
+
+
+@patch.dict("os.environ", TEST_ENVIRONMENT)
+def test_unknown_flavour():
+    with pytest.raises(ConnectionParamsError) as err:
+        get_connector("unknown_flavour").get_connection()
+
+    assert str(err.value) == (
+        "Could not connect to unknown_flavour: unsupported database type newdb"
+    )
+
+
+@patch.dict("os.environ", TEST_ENVIRONMENT)
+def test_get_connector_same_connection():
+    with patch("psycopg2.connect", **{"return_value.closed": False}) as mocked_conn:
+        connector = get_connector("postgres_simple")
+
+        conn = connector.get_connection()
+        assert conn
+
+        assert connector.get_connection() == conn
+        mocked_conn.assert_called_once()
+
+        connector.close()
+        conn.close.assert_called()
+        connector.close()
+        conn.close.assert_called_once()
+
+
+@patch.dict("os.environ", TEST_ENVIRONMENT)
+def test_get_connector_closed_connection():
+    with patch("pyexasol.connect") as mocked_conn:
+        connector = get_connector("exasol_multi_server")
+        conn = connector.get_connection()
+
+        conn.is_closed = False
+        connector.get_connection()
+
+        conn.is_closed = True
+        connector.get_connection()
+
+        assert mocked_conn.call_count == 2


### PR DESCRIPTION
- Added new lower-level interface for interacting with connector object directly using `revlibs.connections.get_connector` function
- Added connectors base class `BaseConnector`
- Connection errors are now raised with custom library exceptions (`ConnectionParamsError` or `ConnectionEstablishError`) instead of generic `Exception` or exceptions spawned by inner connection library. Exceptions from internal connection libraries are now chained with raised custom exceptions for transparency and to ease debugging
- Fixed issues https://github.com/revolut-engineering/data-libs/issues/44 and https://github.com/revolut-engineering/data-libs/issues/42
- Improved docstrings and type annotations
- Improved tests coverage
- Bumped `revlibs.connections` version